### PR TITLE
Allow Chip to respond to font sizing changes

### DIFF
--- a/src/components/Chip.js
+++ b/src/components/Chip.js
@@ -294,7 +294,7 @@ const styles = StyleSheet.create({
     padding: 4,
   },
   text: {
-    height: 24,
+    minHeight: 24,
     lineHeight: 24,
     textAlignVertical: 'center',
     marginVertical: 4,


### PR DESCRIPTION
The Chip component previously had a strict height; this has now been changed to a min height, allowing it to respond to font sizing changes.